### PR TITLE
Correct Typos and Spelling Errors in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Immutable Wallet Contracts
 
-This is a fork of of Sequence's [wallet-contracts repo](https://github.com/0xsequence/wallet-contracts).
+This is a fork of Sequence's [wallet-contracts repo](https://github.com/0xsequence/wallet-contracts).
 
 ## Immutable Changes
 
@@ -24,7 +24,7 @@ The following changes have been made:
   contract address matches being generated using the image hash, the factory
   contract, and the proxy start-up bytes (which include the address of the
   wallet implementation contract: the instance of `StartupWalletImpl`). The
-  image hash is stored and subsequence transactions verify by comparing the
+  image hash is stored and subsequent transactions verify by comparing the
   calculated image hash with the stored image hash.
 - Tests for the new wallet factory features have been included in
   `ImmutableFactory.spec.ts`.
@@ -35,17 +35,17 @@ The following changes have been made:
 
 ## Security Review
 
-`@imtbl/wallet-contracts` has been audited by three independant parties
+`@imtbl/wallet-contracts` has been audited by three independent parties
 
 - [Consensys Diligence](./audits/Consensys_Diligence.md) - May 2020
 - [Quantstamp - initial audit](./audits/Quantstamp_Arcadeum_Report_Final.pdf) - July 2020
 - [Quantstamp - audit of new capability, nested Sequence signers](./audits/sequence_quantstamp_audit_feb_2021.pdf) - Feb 2021
-- [Halborm - audit of security improvements and customisations for Immutable environment](./audits/202309_Halborn_Final.pdf) - Sept 2023. 
+- [Halborn - audit of security improvements and customisations for Immutable environment](./audits/202309_Halborn_Final.pdf) - Sept 2023. 
 See [background information for this audit](./audits/202309_audit_background.md). 
 
 ## Dev env & release
 
-This repository is configured as a yarn workspace, and has multiple pacakge.json
+This repository is configured as a yarn workspace, and has multiple package.json
 files. Specifically, we have the root ./package.json for the development
 environment, contract compilation and testing. Contract source code and
 distribution files are packaged in "src/package.json".
@@ -57,7 +57,7 @@ package in the "src/" folder, separate from the root package.
 ## Contribution
 
 We aim to build robust and feature-rich standards to help all developers onboard
-and build their projects on Immuable zkEVM, and we welcome any and all feedback
+and build their projects on Immutable zkEVM, and we welcome any and all feedback
 and contributions to this repository! See our [contribution
 guideline](CONTRIBUTING.md) for more details on opening Github issues, pull
 requests requesting features, minor security vulnerabilities and providing


### PR DESCRIPTION
### "of of" → "of"

-Removed the duplicate word for grammatical correctness.

### "subsequence" → "subsequent"

-Corrected the usage to the appropriate word in context.

### "independant" → "independent"

-Fixed the spelling error to match standard English.

### "Halborm" → "Halborn"

-Corrected the company name to its accurate spelling.

### "pacakge" → "package"

-Fixed the spelling error .

### "Immuable" → "Immutable"

-Corrected the spelling of "Immutable" to match the branding and correct usage.