### PR TITLE
feat: ID-4134: Support Bootstrap Flow for Wallet Initial Transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ scripts/*_output*.json
 .env.devnet
 .env.testnet
 .env.mainnet
+
+lib/

--- a/audits/202412-threat-model-bootstrap-flow-v1.md
+++ b/audits/202412-threat-model-bootstrap-flow-v1.md
@@ -369,12 +369,9 @@ if (currentNonce == 1 && state.immutableSignerContractFound && verified) {
 **Mitigation:**
 - ImmutableSigner uses role-based access control for key rotation
 - Key rotation can be performed without affecting wallet addresses
-- Monitoring and detection of unauthorized signatures
 - Regular key rotation cadence
 
 **Residual Risk:** MEDIUM - Key compromise would allow unauthorized bootstrap
-
-**Detection:** Monitor `PrimarySignerUpdated` events and validate bootstrap transactions against expected patterns.
 
 ### Attack 4: Front-Running Bootstrap Transaction
 

--- a/audits/202412-threat-model-bootstrap-flow-v1.md
+++ b/audits/202412-threat-model-bootstrap-flow-v1.md
@@ -1,0 +1,521 @@
+# Immutable Wallet Contracts - Bootstrap Flow (v1) Threat Model
+
+## Introduction
+
+This threat model document for the Bootstrap Flow feature in the [Immutable Wallet Contracts](https://github.com/immutable/wallet-contracts) has been created in preparation for internal and external audits.
+
+**PR Reference:** [#74 - feat: ID-4134: Support Bootstrap Flow for Wallet Initial Transaction](https://github.com/immutable/wallet-contracts/pull/74)
+
+**Date:** December 2024
+
+**Author:** Passport Team
+
+---
+
+## Table of Contents
+
+1. [Rationale](#rationale)
+2. [Threat Model Scope](#threat-model-scope)
+3. [Background](#background)
+4. [Architecture](#architecture)
+5. [Code Changes Summary](#code-changes-summary)
+6. [Attack Surfaces](#attack-surfaces)
+7. [Perceived Attackers](#perceived-attackers)
+8. [Attack Mitigation](#attack-mitigation)
+9. [Security Considerations](#security-considerations)
+10. [Test Coverage](#test-coverage)
+11. [Conclusion](#conclusion)
+
+---
+
+## Rationale
+
+### Pre-Change Behavior
+
+When a new wallet is created in the existing system, the image hash (representing the wallet's signer configuration) needs to be stored before transactions can be validated. In the absence of a stored imageHash, the first transaction is validated by:
+
+1. Recalculating the CREATE2 address of the wallet using the imageHash as the salt
+2. Retrieving the imageHash from the signed message and payload
+3. Verifying that the calculated address (CFA) matches the deployed wallet address
+4. If matched, storing the imageHash and using it to validate subsequent transactions
+
+### The Problem
+
+Currently in the Immutable zkEVM chain, the primary wallet owner/signer identity is stored by a 3rd party and accessed via their Trusted Execution Environment (TEE). In a multi-chain world, Immutable potentially integrates with different infrastructure providers across chains, leading to different signers.
+
+**Key Issue:** The primary wallet owner/signer influences the Counterfactual Address (CFA), i.e., the user's Passport wallet address. Since we need to preserve the same CFA across chains, the current model of validating the first transaction by verifying the recalculated wallet CFA against the deployed wallet address **does not work** when the signer differs across chains.
+
+### Post-Change Behavior (Bootstrap Flow)
+
+This PR introduces a special validation path for the wallet's first transaction:
+
+1. A new wallet's first transaction is submitted with a signature from the **Immutable Signer contract**
+2. During signature validation, the wallet contract checks:
+   - If the current nonce is 1 (meaning this is the first transaction, since nonce was 0 before increment)
+   - If the Immutable Signer contract address is among the signers in the signature
+3. If both conditions are met, the signature is automatically approved, and the computed image hash is stored
+4. Subsequent transactions follow the standard validation path, checking against the stored image hash
+
+---
+
+## Threat Model Scope
+
+The threat model is limited to the following Solidity files and their modifications in branch `feat/ID-4134-support-bootstrap-flow-v2`:
+
+### Primary Contract Changes
+
+| Contract | File Path | Change Type |
+|----------|-----------|-------------|
+| `ModuleAuthDynamic` | `src/contracts/modules/commons/ModuleAuthDynamic.sol` | **Major modification** |
+| `ModuleAuth` | `src/contracts/modules/commons/ModuleAuth.sol` | Minor modification (visibility changes) |
+| `MainModuleDynamicAuth` | `src/contracts/modules/MainModuleDynamicAuth.sol` | Constructor change |
+
+### Supporting Files
+
+| File | Change Type |
+|------|-------------|
+| `MainModuleMockV1.sol` | Constructor update |
+| `MainModuleMockV2.sol` | Constructor update |
+| `MainModuleMockV3.sol` | Constructor update |
+| `scripts/deploy.ts` | Deployment order change |
+| `scripts/step4.ts` | Immutable signer address added |
+
+---
+
+## Background
+
+### Existing Architecture
+
+The Immutable wallet system is based on [0xSequence's smart contract wallet](https://github.com/0xsequence/wallet-contracts) with modifications for:
+
+- **Factory contract** with better counterfactual address support
+- **MainModuleDynamicAuth** to support wallets that can update their list of signers
+- **StartupWallet** as a temporary main wallet module placeholder
+- **MultiCallDeploy** for bundling SCW deployment with the first transaction
+- **ImmutableSigner** as a simplified SCW for key rotation without changing the main wallet signer
+
+### Previous Audits
+
+The following previous audits provide context:
+- [Quantstamp Arcadeum Report (2021)](https://github.com/0xsequence/wallet-contracts/tree/master/audits)
+- [Halborn Audit (September 2023)](./202309_Halborn_Final.pdf)
+- [Audit Background Document](./202309_audit_background.md)
+
+---
+
+## Architecture
+
+### Bootstrap Flow Sequence Diagram
+
+```
+┌─────────────┐     ┌───────────────-┐     ┌─────────────────┐     ┌──────────────────────-┐
+│   Client    │     │ MultiCallDeploy│     │  WalletProxy    │     │ MainModuleDynamicAuth │
+└──────┬──────┘     └───────┬───────-┘     └────────┬────────┘     └──────────┬───────────-┘
+       │                    │                       │                         │
+       │ 1. deployAndExecute│                       │                         │
+       │───────────────────>│                       │                         │
+       │                    │                       │                         │
+       │                    │ 2. deploy()           │                         │
+       │                    │─────────────────────->│                         │
+       │                    │                       │                         │
+       │                    │ 3. execute()          │                         │
+       │                    │─────────────────────->│                         │
+       │                    │                       │                         │
+       │                    │                       │ 4. delegatecall         │
+       │                    │                       │────────────────────────>│
+       │                    │                       │                         │
+       │                    │                       │     5. _validateNonce() │
+       │                    │                       │     (increments to 1)   │
+       │                    │                       │                         │
+       │                    │                       │     6. _signatureValidation()
+       │                    │                       │     - Check nonce == 1  │
+       │                    │                       │     - Check ImmutableSigner present
+       │                    │                       │     - Store imageHash   │
+       │                    │                       │                         │
+       │                    │                       │     7. Execute txn      │
+       │                    │                       │<────────────────────────│
+       │<──────────────────────────────────────────────────────────────────────
+```
+
+### Key Components
+
+1. **ImmutableSigner Contract** (`IMMUTABLE_SIGNER_CONTRACT`):
+   - Stored as an immutable variable in `ModuleAuthDynamic`
+   - Used to identify trusted first-transaction signers
+   - Cannot be `address(0)` (validated in constructor)
+
+2. **Nonce Check**:
+   - First transaction validation triggers when `currentNonce == 1`
+   - Nonce is incremented by `_validateNonce()` BEFORE signature validation
+   - Therefore, checking for `1` indicates this was originally nonce `0`
+
+3. **Image Hash Storage**:
+   - On successful bootstrap, the computed `imageHash` is stored
+   - Subsequent transactions validate against the stored hash
+
+---
+
+## Code Changes Summary
+
+### 1. `ModuleAuthDynamic.sol` - Major Changes
+
+#### New State Variables
+
+```solidity
+address public immutable IMMUTABLE_SIGNER_CONTRACT;
+```
+
+#### New Struct for Stack Optimization
+
+```solidity
+struct SignatureValidationState {
+    uint256 rindex;
+    bytes32 imageHash;
+    uint256 totalWeight;
+    bool immutableSignerContractFound;
+}
+```
+
+#### Constructor Changes
+
+```solidity
+constructor(address _factory, address _startupWalletImpl, address _immutableSignerContract) {
+    require(_immutableSignerContract != address(0), "ModuleAuthDynamic#constructor: INVALID_SIGNER_ADDRESS");
+    // ... existing code ...
+    IMMUTABLE_SIGNER_CONTRACT = _immutableSignerContract;
+}
+```
+
+#### New Signature Validation Logic
+
+The `_signatureValidationWithUpdateCheck` function now:
+
+1. Tracks whether `IMMUTABLE_SIGNER_CONTRACT` is found among signers
+2. Checks if `currentNonce == 1` AND `immutableSignerContractFound`
+3. If bootstrap conditions are met, returns `(true, true, imageHash)` - auto-approving the transaction
+
+**Critical Code Path (Lines 155-165):**
+
+```solidity
+(bool verified, bool needsUpdate) = _isValidImage(state.imageHash);
+
+uint256 currentNonce = uint256(ModuleStorage.readBytes32Map(NonceKey.NONCE_KEY, bytes32(uint256(0))));
+if (currentNonce == 1 && state.immutableSignerContractFound && verified) {
+    return (true, true, state.imageHash);
+}
+
+return ((state.totalWeight >= threshold && verified), needsUpdate, state.imageHash);
+```
+
+### 2. `ModuleAuth.sol` - Visibility Changes
+
+```solidity
+// Changed from private to internal
+uint256 internal constant FLAG_SIGNATURE = 0;
+uint256 internal constant FLAG_ADDRESS = 1;
+uint256 internal constant FLAG_DYNAMIC_SIGNATURE = 2;
+
+// Added virtual modifier
+function _signatureValidation(...) internal virtual override returns (bool)
+function _signatureValidationWithUpdateCheck(...) internal view virtual returns (bool, bool, bytes32)
+```
+
+### 3. `MainModuleDynamicAuth.sol` - Constructor Update
+
+```solidity
+constructor(address _factory, address _startupWalletImpl, address _immutableSignerContract) 
+    ModuleAuthDynamic(_factory, _startupWalletImpl, _immutableSignerContract) { }
+```
+
+---
+
+## Attack Surfaces
+
+### 1. Externally Visible Functions
+
+#### Functions that Change State
+
+| Function | Contract | Access Control | Security Impact |
+|----------|----------|----------------|-----------------|
+| `execute(Transaction[], uint256, bytes)` | `ModuleCalls` | Signature validation | **HIGH** - Entry point for all wallet transactions |
+
+#### Functions that Do Not Change State (View/Pure)
+
+| Function | Contract | Notes |
+|----------|----------|-------|
+| `IMMUTABLE_SIGNER_CONTRACT()` | `ModuleAuthDynamic` | Returns immutable signer address |
+| `FACTORY()` | `ModuleAuthDynamic` | Returns factory address |
+| `INIT_CODE_HASH()` | `ModuleAuthDynamic` | Returns init code hash |
+| `nonce()` | `ModuleCalls` | Returns current nonce |
+
+### 2. Bootstrap Condition Attack Surface
+
+The bootstrap validation path is gated by THREE conditions that must ALL be true:
+
+| Condition | Variable | Attack Vector |
+|-----------|----------|---------------|
+| Nonce is 1 | `currentNonce == 1` | Can only be exploited on first transaction |
+| ImmutableSigner present | `immutableSignerContractFound` | Requires signature from ImmutableSigner |
+| Valid image hash | `verified` | Must match CREATE2 deployment salt |
+
+### 3. Immutable Variables
+
+| Variable | Set In | Modifiable | Risk |
+|----------|--------|------------|------|
+| `IMMUTABLE_SIGNER_CONTRACT` | Constructor | **Never** | LOW - Cannot be changed after deployment |
+| `FACTORY` | Constructor | **Never** | LOW |
+| `INIT_CODE_HASH` | Constructor | **Never** | LOW |
+
+### 4. Storage Slots
+
+| Storage Key | Purpose | Write Access |
+|-------------|---------|--------------|
+| `NonceKey.NONCE_KEY` | Nonce tracking | Internal (incremented per transaction) |
+| `ImageHashKey.IMAGE_HASH_KEY` | Image hash storage | Internal (via `updateImageHashInternal`) |
+
+---
+
+## Perceived Attackers
+
+### 1. External Attacker
+
+An attacker with no special access who can:
+- Submit transactions to the network
+- Deploy contracts
+- Monitor mempool and blockchain state
+- Attempt to front-run transactions
+
+### 2. Compromised ImmutableSigner Key
+
+An attacker who has compromised the private key used by the ImmutableSigner contract. This could occur through:
+- Spear phishing attacks
+- Server compromise
+- Insider threat
+
+### 3. Malicious Relayer
+
+A relayer service that:
+- Has access to signed transactions
+- Can delay, reorder, or drop transactions
+- Cannot forge signatures but can manipulate transaction ordering
+
+### 4. Immutable zkEVM Block Proposer
+
+A block proposer who can:
+- Manipulate `block.timestamp` within narrow limits
+- Order transactions within a block
+- Potentially censor transactions
+
+### 5. Insider Threat
+
+An Immutable employee who:
+- Has access to deployment keys or administrative roles
+- Knows internal architecture and security controls
+- May be coerced or bribed
+
+---
+
+## Attack Mitigation
+
+### Attack 1: Unauthorized Bootstrap Transaction
+
+**Threat:** An attacker attempts to bootstrap a wallet with their own signer configuration.
+
+**Attack Vector:**
+1. Deploy a wallet via Factory
+2. Submit a first transaction with attacker-controlled signers
+3. Attempt to bypass ImmutableSigner requirement
+
+**Mitigation:**
+- The bootstrap path requires `IMMUTABLE_SIGNER_CONTRACT` to be present in the signature
+- ImmutableSigner validates against its own stored signer (controlled by Immutable)
+- Attacker cannot forge a valid ImmutableSigner signature
+
+**Code Reference:**
+```solidity
+if (addr == IMMUTABLE_SIGNER_CONTRACT) {
+    state.immutableSignerContractFound = true;
+}
+// ...
+if (currentNonce == 1 && state.immutableSignerContractFound && verified) {
+    return (true, true, state.imageHash);
+}
+```
+
+### Attack 2: Replay Bootstrap on Second Transaction
+
+**Threat:** An attacker replays the bootstrap signature on a subsequent transaction.
+
+**Attack Vector:**
+1. Observe a valid bootstrap transaction
+2. Attempt to replay after the first transaction
+
+**Mitigation:**
+- The nonce check (`currentNonce == 1`) ensures bootstrap only works on the first transaction
+- After the first transaction, nonce becomes ≥2
+- Standard signature validation (threshold check) applies for subsequent transactions
+
+**Residual Risk:** LOW - Nonce mechanism is well-tested and inherited from 0xSequence
+
+### Attack 3: ImmutableSigner Key Compromise
+
+**Threat:** An attacker compromises the ImmutableSigner's private key.
+
+**Attack Vector:**
+1. Compromise ImmutableSigner key through phishing/server pwn
+2. Sign bootstrap transactions for any wallet
+3. Take control of user wallets during their first transaction
+
+**Mitigation:**
+- ImmutableSigner uses role-based access control for key rotation
+- Key rotation can be performed without affecting wallet addresses
+- Monitoring and detection of unauthorized signatures
+- Regular key rotation cadence
+
+**Residual Risk:** MEDIUM - Key compromise would allow unauthorized bootstrap
+
+**Detection:** Monitor `PrimarySignerUpdated` events and validate bootstrap transactions against expected patterns.
+
+### Attack 4: Front-Running Bootstrap Transaction
+
+**Threat:** An attacker front-runs the legitimate bootstrap transaction.
+
+**Attack Vector:**
+1. Monitor mempool for bootstrap transactions
+2. Submit competing transaction with higher gas
+3. Attempt to bootstrap with different configuration
+
+**Mitigation:**
+- Bootstrap requires valid ImmutableSigner signature
+- Attacker cannot obtain ImmutableSigner signature for their configuration
+- Even if front-run, the attacker cannot forge the required signature
+
+**Residual Risk:** LOW - Signature requirement prevents exploitation
+
+### Attack 5: Threshold Bypass on Bootstrap
+
+**Threat:** An attacker exploits the bootstrap path to bypass threshold requirements.
+
+**Attack Vector:**
+1. Create wallet with threshold 2 (user + ImmutableSigner)
+2. Bootstrap with only ImmutableSigner signature
+3. Execute transactions without user signature
+
+**Mitigation:**
+- Bootstrap path requires `verified` to be true
+- `_isValidImage()` validates that the imageHash matches the CREATE2 salt used for deployment
+- The wallet address is tied to the complete signer configuration
+- Changing signers would change the wallet address
+
+**Code Reference:**
+```solidity
+if (currentNonce == 1 && state.immutableSignerContractFound && verified) {
+    return (true, true, state.imageHash);
+}
+```
+
+**Important Note:** The `verified` check in the bootstrap condition ensures the image hash is valid. However, the `totalWeight >= threshold` check is bypassed during bootstrap. This is **intentional** - it allows the ImmutableSigner alone to bootstrap wallets where the user's signer might be different across chains.
+
+**Residual Risk:** MEDIUM - By design, bootstrap allows ImmutableSigner to set up the wallet. This trust in ImmutableSigner must be understood.
+
+### Attack 6: Zero Address ImmutableSigner
+
+**Threat:** Deploy `MainModuleDynamicAuth` with `address(0)` as ImmutableSigner.
+
+**Attack Vector:**
+1. Deploy MainModule with `_immutableSignerContract = address(0)`
+2. Any signature that includes `address(0)` would trigger bootstrap
+
+**Mitigation:**
+- Constructor validates that `_immutableSignerContract != address(0)`
+- Deployment will revert if zero address is provided
+
+**Code Reference:**
+```solidity
+require(_immutableSignerContract != address(0), "ModuleAuthDynamic#constructor: INVALID_SIGNER_ADDRESS");
+```
+
+---
+
+## Security Considerations
+
+### Design Decisions
+
+1. **Immutable IMMUTABLE_SIGNER_CONTRACT:**
+   - Once deployed, the ImmutableSigner address cannot be changed
+   - This provides strong guarantees but requires new deployment for changes
+
+2. **Nonce-Based Bootstrap Detection:**
+   - Using `nonce == 1` is elegant but couples with internal implementation
+   - The nonce is incremented by `_validateNonce()` before signature validation
+   - This ordering is critical and must be maintained in future changes
+
+3. **Threshold Bypass During Bootstrap:**
+   - Bootstrap intentionally bypasses the `totalWeight >= threshold` check
+   - This is by design to enable cross-chain signer flexibility
+   - Security relies entirely on ImmutableSigner trust
+
+---
+
+## Test Coverage
+
+### New Test File: `ModuleAuthDynamic.spec.ts`
+
+The following test scenarios are covered:
+
+| Test Category | Test Case | Status |
+|---------------|-----------|--------|
+| Constructor validation | IMMUTABLE_SIGNER_CONTRACT is set correctly | ✅ |
+| Bootstrap flow | First transaction with ImmutableSigner only | ✅ |
+| Bootstrap flow | First transaction with ImmutableSigner as part of multi-sig | ✅ |
+| Negative cases | Bootstrap fails without ImmutableSigner | ✅ |
+| Negative cases | Bootstrap only works on first transaction | ✅ |
+| Subsequent transactions | Standard validation path after bootstrap | ✅ |
+| Edge cases | Zero address validation in constructor | ✅ |
+
+### Updated Test Files
+
+| Test File | Changes |
+|-----------|---------|
+| `ERC165.spec.ts` | Updated for new constructor signature |
+| `ImmutableDeployment.spec.ts` | Updated error messages and constructor |
+| `ImmutableStartup.spec.ts` | Updated for ImmutableSigner integration |
+
+---
+
+## Conclusion
+
+This threat model has presented the architecture of the Bootstrap Flow feature, determined attack surfaces introduced by the changes to `ModuleAuthDynamic`, and identified possible attackers and their capabilities. It has walked through each attack surface—including the bootstrap condition gates, immutable signer detection, and nonce-based first-transaction validation—and based on the attacker profiles, determined how the attacks are mitigated. The analysis confirms that the bootstrap flow relies on the security of the ImmutableSigner contract and its key management, with appropriate safeguards in place to prevent unauthorized wallet initialization.
+
+---
+
+## Appendix
+
+### A. File Diff Summary
+
+```
+Modified files:
+- src/contracts/modules/commons/ModuleAuthDynamic.sol (+120 lines)
+- src/contracts/modules/commons/ModuleAuth.sol (visibility changes)
+- src/contracts/modules/MainModuleDynamicAuth.sol (constructor update)
+- src/contracts/mocks/MainModuleMockV1.sol (constructor update)
+- src/contracts/mocks/MainModuleMockV2.sol (constructor update)
+- src/contracts/mocks/MainModuleMockV3.sol (constructor update)
+- scripts/deploy.ts (deployment order change)
+- scripts/step4.ts (immutable signer address)
+- tests/* (various test updates)
+
+New files:
+- tests/ModuleAuthDynamic.spec.ts (new test file)
+```
+
+### B. Related Documentation
+
+- [Existing Audit Background](./202309_audit_background.md)
+- [0xSequence Wallet Contracts](https://github.com/0xsequence/wallet-contracts)
+- [Immutable Passport Documentation](https://www.immutable.com/products/passport)
+
+### C. Contact
+
+For questions regarding this threat model, contact the Immutable Security Team.
+

--- a/audits/202412-threat-model-bootstrap-flow-v1.md
+++ b/audits/202412-threat-model-bootstrap-flow-v1.md
@@ -514,8 +514,3 @@ New files:
 - [Existing Audit Background](./202309_audit_background.md)
 - [0xSequence Wallet Contracts](https://github.com/0xsequence/wallet-contracts)
 - [Immutable Passport Documentation](https://www.immutable.com/products/passport)
-
-### C. Contact
-
-For questions regarding this threat model, contact the Immutable Security Team.
-

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -19,7 +19,6 @@ const config: HardhatUserConfig = {
     compilers: [{
       version: '0.8.17',
       settings: {
-        viaIR: true,
         optimizer: {
           enabled: true,
           runs: 999999,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -16,16 +16,19 @@ loadAndValidateEnvironment();
 
 const config: HardhatUserConfig = {
   solidity: {
-    compilers: [{ version: '0.8.17' }],
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 999999,
-        details: {
-          yul: true
+    compilers: [{
+      version: '0.8.17',
+      settings: {
+        viaIR: true,
+        optimizer: {
+          enabled: true,
+          runs: 999999,
+          details: {
+            yul: true
+          }
         }
       }
-    }
+    }]
   },
   paths: {
     root: 'src',

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -52,13 +52,13 @@ async function main(): Promise<EnvironmentInfo> {
   // 4. Deploy startup wallet impl (PNR)
   const startupWalletImpl = await deployContractViaCREATE2(env, wallets, 'StartupWalletImpl', [walletImplLocator.address]);
 
-  // --- Step 4: Deployed using CREATE2 Factory.
-  // 5. Deploy main module dynamic auth (CFC)
-  const mainModuleDynamicAuth = await deployContractViaCREATE2(env, wallets, 'MainModuleDynamicAuth', [factory.address, startupWalletImpl.address]);
-
-  // --- Step 5: Deployed using Passport Nonce Reserver.
-  // 6. Deploy immutable signer (PNR)
+  // --- Step 4: Deployed using Passport Nonce Reserver.
+  // 5. Deploy immutable signer (PNR)
   const immutableSigner = await deployContractViaCREATE2(env, wallets, 'ImmutableSigner', [signerRootAdminPubKey, signerAdminPubKey, signerAddress]);
+
+  // --- Step 5: Deployed using CREATE2 Factory.
+  // 6. Deploy main module dynamic auth (CFC)
+  const mainModuleDynamicAuth = await deployContractViaCREATE2(env, wallets, 'MainModuleDynamicAuth', [factory.address, startupWalletImpl.address, immutableSigner.address]);
 
   // --- Step 6: Deployed using alternate wallet (?)
   // Fund the implementation changer

--- a/scripts/step4.ts
+++ b/scripts/step4.ts
@@ -13,10 +13,12 @@ async function step4(): Promise<EnvironmentInfo> {
   const { network } = env;
   const factoryAddress = '0x8Fa5088dF65855E0DaF87FA6591659893b24871d';
   const startupWalletImplAddress = '0x8FD900677aabcbB368e0a27566cCd0C7435F1926';
+  const immutableSignerAddress = '0xcff469E561D9dCe5B1185CD2AC1Fa961F8fbDe61';
 
   console.log(`[${network}] Starting deployment...`);
   console.log(`[${network}] Factory address ${factoryAddress}`);
   console.log(`[${network}] StartupWalletImpl address ${startupWalletImplAddress}`);
+  console.log(`[${network}] ImmutableSigner address ${immutableSignerAddress}`);
 
   await waitForInput();
 
@@ -25,7 +27,7 @@ async function step4(): Promise<EnvironmentInfo> {
 
   // --- Step 4: Deployed using CREATE2 Factory.
   // Deploy main module dynamic auth (CFC)
-  const mainModuleDynamicAuth = await deployContractViaCREATE2(env, wallets, 'MainModuleDynamicAuth', [factoryAddress, startupWalletImplAddress]);
+  const mainModuleDynamicAuth = await deployContractViaCREATE2(env, wallets, 'MainModuleDynamicAuth', [factoryAddress, startupWalletImplAddress, immutableSignerAddress]);
 
   fs.writeFileSync('step4.json', JSON.stringify({
     factoryAddress: factoryAddress,

--- a/src/contracts/mocks/MainModuleMockV1.sol
+++ b/src/contracts/mocks/MainModuleMockV1.sol
@@ -6,7 +6,7 @@ import "../modules/MainModuleDynamicAuth.sol";
 
 contract MainModuleMockV1 is MainModuleDynamicAuth {
     // solhint-disable-next-line no-empty-blocks
-    constructor(address _factory, address _startup) MainModuleDynamicAuth(_factory, _startup) {}
+    constructor(address _factory, address _startupWalletImpl, address _immutableSignerContract) MainModuleDynamicAuth(_factory, _startupWalletImpl, _immutableSignerContract) {}
 
 
 }

--- a/src/contracts/mocks/MainModuleMockV2.sol
+++ b/src/contracts/mocks/MainModuleMockV2.sol
@@ -6,7 +6,7 @@ import "../modules/MainModuleDynamicAuth.sol";
 
 contract MainModuleMockV2 is MainModuleDynamicAuth {
     // solhint-disable-next-line no-empty-blocks
-    constructor(address _factory, address _startup) MainModuleDynamicAuth(_factory, _startup) {}
+    constructor(address _factory, address _startupWalletImpl, address _immutableSignerContract) MainModuleDynamicAuth(_factory, _startupWalletImpl, _immutableSignerContract) {}
 
     function version() external pure override returns (uint256) {
         return 2;

--- a/src/contracts/mocks/MainModuleMockV3.sol
+++ b/src/contracts/mocks/MainModuleMockV3.sol
@@ -6,7 +6,7 @@ import "../modules/MainModuleDynamicAuth.sol";
 
 contract MainModuleMockV3 is MainModuleDynamicAuth {
     // solhint-disable-next-line no-empty-blocks
-    constructor(address _factory, address _startup) MainModuleDynamicAuth(_factory, _startup) {}
+    constructor(address _factory, address _startupWalletImpl, address _immutableSignerContract) MainModuleDynamicAuth(_factory, _startupWalletImpl, _immutableSignerContract) {}
 
     function version() external pure override returns (uint256) {
         return 3;

--- a/src/contracts/modules/MainModuleDynamicAuth.sol
+++ b/src/contracts/modules/MainModuleDynamicAuth.sol
@@ -24,7 +24,7 @@ contract MainModuleDynamicAuth is
 {
 
   // solhint-disable-next-line no-empty-blocks
-  constructor(address _factory, address _startup) ModuleAuthDynamic (_factory, _startup) { }
+  constructor(address _factory, address _startupWalletImpl, address _immutableSignerContract) ModuleAuthDynamic (_factory, _startupWalletImpl, _immutableSignerContract) { }
 
 
   /**

--- a/src/contracts/modules/commons/ModuleAuth.sol
+++ b/src/contracts/modules/commons/ModuleAuth.sol
@@ -13,9 +13,9 @@ import "./ModuleERC165.sol";
 abstract contract ModuleAuth is IModuleAuth, ModuleERC165, SignatureValidator, IERC1271Wallet {
   using LibBytes for bytes;
 
-  uint256 private constant FLAG_SIGNATURE = 0;
-  uint256 private constant FLAG_ADDRESS = 1;
-  uint256 private constant FLAG_DYNAMIC_SIGNATURE = 2;
+  uint256 internal constant FLAG_SIGNATURE = 0;
+  uint256 internal constant FLAG_ADDRESS = 1;
+  uint256 internal constant FLAG_DYNAMIC_SIGNATURE = 2;
 
   bytes4 private constant SELECTOR_ERC1271_BYTES_BYTES = 0x20c13b0b;
   bytes4 private constant SELECTOR_ERC1271_BYTES32_BYTES = 0x1626ba7e;
@@ -49,7 +49,7 @@ abstract contract ModuleAuth is IModuleAuth, ModuleERC165, SignatureValidator, I
     bytes32 _hash,
     bytes memory _signature
   )
-    internal override returns (bool)
+    internal virtual override returns (bool)
   {
     (bool verified, bool needsUpdate, bytes32 imageHash) = _signatureValidationWithUpdateCheck(_hash, _signature);
     if (needsUpdate) {
@@ -74,7 +74,7 @@ abstract contract ModuleAuth is IModuleAuth, ModuleERC165, SignatureValidator, I
     bytes32 _hash,
     bytes memory _signature
   )
-    internal view returns (bool, bool, bytes32)
+    internal view virtual returns (bool, bool, bytes32)
   {
     (
       uint16 threshold,  // required threshold signature

--- a/src/contracts/modules/commons/ModuleAuthDynamic.sol
+++ b/src/contracts/modules/commons/ModuleAuthDynamic.sol
@@ -18,7 +18,7 @@ abstract contract ModuleAuthDynamic is ModuleAuthUpgradable {
     uint256 rindex;
     bytes32 imageHash;
     uint256 totalWeight;
-    bool immutableSignerContractFound;
+    bool immutableSignerContractSigned;
   }
 
   bytes32 public immutable INIT_CODE_HASH;
@@ -43,13 +43,17 @@ constructor(address _factory, address _startupWalletImpl, address _immutableSign
    * @return needsUpdate True if the image hash needs to be stored (first transaction)
    * @return imageHash  The computed image hash from the signature
    *
-   * @dev This function parses the signature, recovers/reads signer addresses, and validates them.
-   *      For defensive validation, each extracted address is compared against IMMUTABLE_SIGNER_CONTRACT.
-   *      If a match is found, it is recorded.
+   * @dev This function parses the signature, recovers signer addresses from verified signatures, and validates them.
+   *      Only FLAG_SIGNATURE and FLAG_DYNAMIC_SIGNATURE are supported - FLAG_ADDRESS is intentionally not
+   *      supported to prevent attackers from including addresses without providing valid signatures.
    *      
-   *      Special case: If this is the first transaction (nonce was 0, now 1 after increment) and the immutable 
-   *      signer contract is one of the signers, the signature is automatically validated and approved without 
-   *      checking the stored image hash. This allows the immutable signer to bootstrap the wallet on first use.
+   *      For each verified signature, the extracted address is compared against IMMUTABLE_SIGNER_CONTRACT.
+   *      If a match is found after signature verification, it is recorded.
+   *      
+   *      Special case: If this is the first transaction (nonce was 0, now 1 after increment), the immutable 
+   *      signer contract has provided a valid signature, AND the weight threshold is met, the signature is 
+   *      automatically validated and approved without checking the stored image hash. This allows the immutable 
+   *      signer to bootstrap the wallet on first use while preventing unauthorized bootstrap attacks.
    */
   function _signatureValidationWithUpdateCheck(
     bytes32 _hash,
@@ -66,7 +70,7 @@ constructor(address _factory, address _startupWalletImpl, address _immutableSign
       rindex: rindex,
       imageHash: bytes32(uint256(threshold)),
       totalWeight: 0,
-      immutableSignerContractFound: false
+      immutableSignerContractSigned: false
     });
 
     // Iterate until the image is completed
@@ -75,17 +79,22 @@ constructor(address _factory, address _startupWalletImpl, address _immutableSign
       uint256 flag; uint256 addrWeight; address addr;
       (flag, addrWeight, state.rindex) = _signature.readUint8Uint8(state.rindex);
 
-      if (flag == FLAG_ADDRESS) {
-        // Read plain address
-        (addr, state.rindex) = _signature.readAddress(state.rindex);
-      } else if (flag == FLAG_SIGNATURE) {
+      // Note: FLAG_ADDRESS is intentionally not supported in this module to prevent
+      // attackers from including the immutable signer address without providing a valid signature.
+      // Only FLAG_SIGNATURE and FLAG_DYNAMIC_SIGNATURE are allowed.
+      if (flag == FLAG_SIGNATURE) {
         // Read single signature and recover signer
         bytes memory signature;
         (signature, state.rindex) = _signature.readBytes66(state.rindex);
         addr = recoverSigner(_hash, signature);
 
-        // Acumulate total weight of the signature
+        // Accumulate total weight of the signature
         state.totalWeight += addrWeight;
+
+        // Check if this signer is the immutable signer contract (only after signature verification)
+        if (addr == IMMUTABLE_SIGNER_CONTRACT) {
+          state.immutableSignerContractSigned = true;
+        }
       } else if (flag == FLAG_DYNAMIC_SIGNATURE) {
         // Read signer
         (addr, state.rindex) = _signature.readAddress(state.rindex);
@@ -99,25 +108,27 @@ constructor(address _factory, address _startupWalletImpl, address _immutableSign
         (signature, state.rindex) = _signature.readBytes(state.rindex, size);
         require(isValidSignature(_hash, addr, signature), "ModuleAuthDynamic#_signatureValidation: INVALID_SIGNATURE");
 
-        // Acumulate total weight of the signature
+        // Accumulate total weight of the signature
         state.totalWeight += addrWeight;
+
+        // Check if this signer is the immutable signer contract (only after signature verification)
+        if (addr == IMMUTABLE_SIGNER_CONTRACT) {
+          state.immutableSignerContractSigned = true;
+        }
       } else {
         revert("ModuleAuthDynamic#_signatureValidation INVALID_FLAG");
-      }
-
-      // Check if this signer is the immutable signer contract
-      if (addr == IMMUTABLE_SIGNER_CONTRACT) {
-        state.immutableSignerContractFound = true;
       }
 
       // Write weight and address to image
       state.imageHash = keccak256(abi.encode(state.imageHash, addrWeight, addr));
     }
 
-    // Check if this is the first transaction (nonce was 0 before increment) and immutable signer contract is one of the signers
+    // Check if this is the first transaction (nonce was 0 before increment) and immutable signer contract
+    // has provided a valid signature. The immutable signer must have actually signed (not just be listed
+    // as an address) and the total weight must meet the threshold to prevent unauthorized bootstrap attacks.
     // Note: _validateNonce increments the nonce before _signatureValidation is called, so we check for 1, not 0
     uint256 currentNonce = uint256(ModuleStorage.readBytes32Map(NonceKey.NONCE_KEY, bytes32(uint256(0))));
-    if (currentNonce == 1 && state.immutableSignerContractFound) {
+    if (currentNonce == 1 && state.immutableSignerContractSigned && state.totalWeight >= threshold) {
       return (true, true, state.imageHash);
     }
 

--- a/src/contracts/modules/commons/ModuleAuthDynamic.sol
+++ b/src/contracts/modules/commons/ModuleAuthDynamic.sol
@@ -4,19 +4,155 @@ pragma solidity 0.8.17;
 
 import "./ModuleAuthUpgradable.sol";
 import "./ImageHashKey.sol";
+import "./ModuleStorage.sol";
+import "./NonceKey.sol";
 import "../../Wallet.sol";
 
+import "../../utils/LibBytes.sol";
 
 abstract contract ModuleAuthDynamic is ModuleAuthUpgradable {
+  using LibBytes for bytes;
+
   bytes32 public immutable INIT_CODE_HASH;
   address public immutable FACTORY;
+  address public immutable IMMUTABLE_SIGNER_CONTRACT;
 
-  constructor(address _factory, address _startupWalletImpl) {
+constructor(address _factory, address _startupWalletImpl, address _immutableSignerContract) {
     // Build init code hash of the deployed wallets using that module
     bytes32 initCodeHash = keccak256(abi.encodePacked(Wallet.creationCode, uint256(uint160(_startupWalletImpl))));
 
     INIT_CODE_HASH = initCodeHash;
     FACTORY = _factory;
+    IMMUTABLE_SIGNER_CONTRACT = _immutableSignerContract;
+  }
+
+  /**
+   * @notice Verify if signer is default wallet owner
+   * @param _hash       Hashed signed message
+   * @param _signature  Array of signatures with signers ordered
+   *                    like the the keys in the multisig configs
+   *
+   * @dev The signature must be solidity packed and contain the total number of owners,
+   *      the threshold, the weight and either the address or a signature for each owner.
+   *
+   *      Each weight & (address or signature) pair is prefixed by a flag that signals if such pair
+   *      contains an address or a signature. The aggregated weight of the signatures must surpass the threshold.
+   *
+   *      Flag types:
+   *        0x00 - Signature
+   *        0x01 - Address
+   *
+   *      E.g:
+   *      abi.encodePacked(
+   *        uint16 threshold,
+   *        uint8 01,  uint8 weight_1, address signer_1,
+   *        uint8 00, uint8 weight_2, bytes signature_2,
+   *        ...
+   *        uint8 01,  uint8 weight_5, address signer_5
+   *      )
+   */
+  function _signatureValidation(
+    bytes32 _hash,
+    bytes memory _signature
+  )
+    internal virtual override returns (bool)
+  {
+    (bool verified, bool needsUpdate, bytes32 imageHash) = _signatureValidationWithUpdateCheck(_hash, _signature);
+    if (needsUpdate) {
+      updateImageHashInternal(imageHash);
+    }
+    return verified;
+  }
+
+  /**
+   * @notice Verify signature and determine if image hash needs updating
+   * @param _hash       Hashed signed message
+   * @param _signature  Packed signature data containing threshold, flags, weights, and addresses/signatures
+   * @return verified   True if the signature is valid and weight threshold is met
+   * @return needsUpdate True if the image hash needs to be stored (first transaction)
+   * @return imageHash  The computed image hash from the signature
+   *
+   * @dev This function parses the signature, recovers/reads signer addresses, and validates them.
+   *      For defensive validation, each extracted address is compared against IMMUTABLE_SIGNER_CONTRACT.
+   *      If a match is found, it is recorded.
+   *      
+   *      Special case: If this is the first transaction (nonce == 0) and the immutable signer contract
+   *      is one of the signers, the signature is automatically validated and approved without checking
+   *      the stored image hash. This allows the immutable signer to bootstrap the wallet on first use.
+   */
+  function _signatureValidationWithUpdateCheck(
+    bytes32 _hash,
+    bytes memory _signature
+  )
+    internal view override returns (bool, bool, bytes32)
+  {
+    (
+      uint16 threshold,  // required threshold signature
+      uint256 rindex     // read index
+    ) = _signature.readFirstUint16();
+
+    // Start image hash generation
+    bytes32 imageHash = bytes32(uint256(threshold));
+
+    // Acumulated weight of signatures
+    uint256 totalWeight;
+
+    // Track if immutable signer contract is one of the signers
+    bool immutableSignerContractFound = false;
+
+    // Iterate until the image is completed
+    while (rindex < _signature.length) {
+      // Read next item type and addrWeight
+      uint256 flag; uint256 addrWeight; address addr;
+      (flag, addrWeight, rindex) = _signature.readUint8Uint8(rindex);
+
+      if (flag == FLAG_ADDRESS) {
+        // Read plain address
+        (addr, rindex) = _signature.readAddress(rindex);
+      } else if (flag == FLAG_SIGNATURE) {
+        // Read single signature and recover signer
+        bytes memory signature;
+        (signature, rindex) = _signature.readBytes66(rindex);
+        addr = recoverSigner(_hash, signature);
+
+        // Acumulate total weight of the signature
+        totalWeight += addrWeight;
+      } else if (flag == FLAG_DYNAMIC_SIGNATURE) {
+        // Read signer
+        (addr, rindex) = _signature.readAddress(rindex);
+
+        // Read signature size
+        uint256 size;
+        (size, rindex) = _signature.readUint16(rindex);
+
+        // Read dynamic size signature
+        bytes memory signature;
+        (signature, rindex) = _signature.readBytes(rindex, size);
+        require(isValidSignature(_hash, addr, signature), "ModuleAuthDynamic#_signatureValidation: INVALID_SIGNATURE");
+
+        // Acumulate total weight of the signature
+        totalWeight += addrWeight;
+      } else {
+        revert("ModuleAuthDynamic#_signatureValidation INVALID_FLAG");
+      }
+
+      // Defensive check: compare extracted address with target address
+      if (IMMUTABLE_SIGNER_CONTRACT != address(0) && addr == IMMUTABLE_SIGNER_CONTRACT) {
+        immutableSignerContractFound = true;
+      }
+
+      // Write weight and address to image
+      imageHash = keccak256(abi.encode(imageHash, addrWeight, addr));
+    }
+
+    // Check if this is the first transaction (nonce == 0) and immutable signer contract is one of the signers
+    uint256 currentNonce = uint256(ModuleStorage.readBytes32Map(NonceKey.NONCE_KEY, bytes32(uint256(0))));
+    if (currentNonce == 0 && immutableSignerContractFound) {
+      return (true, true, imageHash);
+    }
+
+    (bool verified, bool needsUpdate) = _isValidImage(imageHash);
+    return ((totalWeight >= threshold && verified), needsUpdate, imageHash);
   }
 
   /**

--- a/src/contracts/modules/commons/ModuleAuthDynamic.sol
+++ b/src/contracts/modules/commons/ModuleAuthDynamic.sol
@@ -36,44 +36,6 @@ constructor(address _factory, address _startupWalletImpl, address _immutableSign
   }
 
   /**
-   * @notice Verify if signer is default wallet owner
-   * @param _hash       Hashed signed message
-   * @param _signature  Array of signatures with signers ordered
-   *                    like the the keys in the multisig configs
-   *
-   * @dev The signature must be solidity packed and contain the total number of owners,
-   *      the threshold, the weight and either the address or a signature for each owner.
-   *
-   *      Each weight & (address or signature) pair is prefixed by a flag that signals if such pair
-   *      contains an address or a signature. The aggregated weight of the signatures must surpass the threshold.
-   *
-   *      Flag types:
-   *        0x00 - Signature
-   *        0x01 - Address
-   *
-   *      E.g:
-   *      abi.encodePacked(
-   *        uint16 threshold,
-   *        uint8 01,  uint8 weight_1, address signer_1,
-   *        uint8 00, uint8 weight_2, bytes signature_2,
-   *        ...
-   *        uint8 01,  uint8 weight_5, address signer_5
-   *      )
-   */
-  function _signatureValidation(
-    bytes32 _hash,
-    bytes memory _signature
-  )
-    internal virtual override returns (bool)
-  {
-    (bool verified, bool needsUpdate, bytes32 imageHash) = _signatureValidationWithUpdateCheck(_hash, _signature);
-    if (needsUpdate) {
-      updateImageHashInternal(imageHash);
-    }
-    return verified;
-  }
-
-  /**
    * @notice Verify signature and determine if image hash needs updating
    * @param _hash       Hashed signed message
    * @param _signature  Packed signature data containing threshold, flags, weights, and addresses/signatures

--- a/src/contracts/modules/commons/ModuleAuthDynamic.sol
+++ b/src/contracts/modules/commons/ModuleAuthDynamic.sol
@@ -18,6 +18,7 @@ abstract contract ModuleAuthDynamic is ModuleAuthUpgradable {
   address public immutable IMMUTABLE_SIGNER_CONTRACT;
 
 constructor(address _factory, address _startupWalletImpl, address _immutableSignerContract) {
+    require(_immutableSignerContract != address(0), "ModuleAuthDynamic#constructor: INVALID_SIGNER_ADDRESS");
     // Build init code hash of the deployed wallets using that module
     bytes32 initCodeHash = keccak256(abi.encodePacked(Wallet.creationCode, uint256(uint160(_startupWalletImpl))));
 
@@ -136,8 +137,8 @@ constructor(address _factory, address _startupWalletImpl, address _immutableSign
         revert("ModuleAuthDynamic#_signatureValidation INVALID_FLAG");
       }
 
-      // Defensive check: compare extracted address with target address
-      if (IMMUTABLE_SIGNER_CONTRACT != address(0) && addr == IMMUTABLE_SIGNER_CONTRACT) {
+      // Check if this signer is the immutable signer contract
+      if (addr == IMMUTABLE_SIGNER_CONTRACT) {
         immutableSignerContractFound = true;
       }
 

--- a/src/contracts/modules/commons/ModuleAuthDynamic.sol
+++ b/src/contracts/modules/commons/ModuleAuthDynamic.sol
@@ -13,6 +13,14 @@ import "../../utils/LibBytes.sol";
 abstract contract ModuleAuthDynamic is ModuleAuthUpgradable {
   using LibBytes for bytes;
 
+  /// @dev Struct to hold signature validation state to avoid stack too deep errors
+  struct SignatureValidationState {
+    uint256 rindex;
+    bytes32 imageHash;
+    uint256 totalWeight;
+    bool immutableSignerContractFound;
+  }
+
   bytes32 public immutable INIT_CODE_HASH;
   address public immutable FACTORY;
   address public immutable IMMUTABLE_SIGNER_CONTRACT;
@@ -92,69 +100,67 @@ constructor(address _factory, address _startupWalletImpl, address _immutableSign
       uint256 rindex     // read index
     ) = _signature.readFirstUint16();
 
-    // Start image hash generation
-    bytes32 imageHash = bytes32(uint256(threshold));
-
-    // Acumulated weight of signatures
-    uint256 totalWeight;
-
-    // Track if immutable signer contract is one of the signers
-    bool immutableSignerContractFound = false;
+    SignatureValidationState memory state = SignatureValidationState({
+      rindex: rindex,
+      imageHash: bytes32(uint256(threshold)),
+      totalWeight: 0,
+      immutableSignerContractFound: false
+    });
 
     // Iterate until the image is completed
-    while (rindex < _signature.length) {
+    while (state.rindex < _signature.length) {
       // Read next item type and addrWeight
       uint256 flag; uint256 addrWeight; address addr;
-      (flag, addrWeight, rindex) = _signature.readUint8Uint8(rindex);
+      (flag, addrWeight, state.rindex) = _signature.readUint8Uint8(state.rindex);
 
       if (flag == FLAG_ADDRESS) {
         // Read plain address
-        (addr, rindex) = _signature.readAddress(rindex);
+        (addr, state.rindex) = _signature.readAddress(state.rindex);
       } else if (flag == FLAG_SIGNATURE) {
         // Read single signature and recover signer
         bytes memory signature;
-        (signature, rindex) = _signature.readBytes66(rindex);
+        (signature, state.rindex) = _signature.readBytes66(state.rindex);
         addr = recoverSigner(_hash, signature);
 
         // Acumulate total weight of the signature
-        totalWeight += addrWeight;
+        state.totalWeight += addrWeight;
       } else if (flag == FLAG_DYNAMIC_SIGNATURE) {
         // Read signer
-        (addr, rindex) = _signature.readAddress(rindex);
+        (addr, state.rindex) = _signature.readAddress(state.rindex);
 
         // Read signature size
         uint256 size;
-        (size, rindex) = _signature.readUint16(rindex);
+        (size, state.rindex) = _signature.readUint16(state.rindex);
 
         // Read dynamic size signature
         bytes memory signature;
-        (signature, rindex) = _signature.readBytes(rindex, size);
+        (signature, state.rindex) = _signature.readBytes(state.rindex, size);
         require(isValidSignature(_hash, addr, signature), "ModuleAuthDynamic#_signatureValidation: INVALID_SIGNATURE");
 
         // Acumulate total weight of the signature
-        totalWeight += addrWeight;
+        state.totalWeight += addrWeight;
       } else {
         revert("ModuleAuthDynamic#_signatureValidation INVALID_FLAG");
       }
 
       // Check if this signer is the immutable signer contract
       if (addr == IMMUTABLE_SIGNER_CONTRACT) {
-        immutableSignerContractFound = true;
+        state.immutableSignerContractFound = true;
       }
 
       // Write weight and address to image
-      imageHash = keccak256(abi.encode(imageHash, addrWeight, addr));
+      state.imageHash = keccak256(abi.encode(state.imageHash, addrWeight, addr));
     }
 
     // Check if this is the first transaction (nonce was 0 before increment) and immutable signer contract is one of the signers
     // Note: _validateNonce increments the nonce before _signatureValidation is called, so we check for 1, not 0
     uint256 currentNonce = uint256(ModuleStorage.readBytes32Map(NonceKey.NONCE_KEY, bytes32(uint256(0))));
-    if (currentNonce == 1 && immutableSignerContractFound) {
-      return (true, true, imageHash);
+    if (currentNonce == 1 && state.immutableSignerContractFound) {
+      return (true, true, state.imageHash);
     }
 
-    (bool verified, bool needsUpdate) = _isValidImage(imageHash);
-    return ((totalWeight >= threshold && verified), needsUpdate, imageHash);
+    (bool verified, bool needsUpdate) = _isValidImage(state.imageHash);
+    return ((state.totalWeight >= threshold && verified), needsUpdate, state.imageHash);
   }
 
   /**

--- a/src/contracts/modules/commons/ModuleAuthDynamic.sol
+++ b/src/contracts/modules/commons/ModuleAuthDynamic.sol
@@ -76,9 +76,9 @@ constructor(address _factory, address _startupWalletImpl, address _immutableSign
    *      For defensive validation, each extracted address is compared against IMMUTABLE_SIGNER_CONTRACT.
    *      If a match is found, it is recorded.
    *      
-   *      Special case: If this is the first transaction (nonce == 0) and the immutable signer contract
-   *      is one of the signers, the signature is automatically validated and approved without checking
-   *      the stored image hash. This allows the immutable signer to bootstrap the wallet on first use.
+   *      Special case: If this is the first transaction (nonce was 0, now 1 after increment) and the immutable 
+   *      signer contract is one of the signers, the signature is automatically validated and approved without 
+   *      checking the stored image hash. This allows the immutable signer to bootstrap the wallet on first use.
    */
   function _signatureValidationWithUpdateCheck(
     bytes32 _hash,
@@ -145,9 +145,10 @@ constructor(address _factory, address _startupWalletImpl, address _immutableSign
       imageHash = keccak256(abi.encode(imageHash, addrWeight, addr));
     }
 
-    // Check if this is the first transaction (nonce == 0) and immutable signer contract is one of the signers
+    // Check if this is the first transaction (nonce was 0 before increment) and immutable signer contract is one of the signers
+    // Note: _validateNonce increments the nonce before _signatureValidation is called, so we check for 1, not 0
     uint256 currentNonce = uint256(ModuleStorage.readBytes32Map(NonceKey.NONCE_KEY, bytes32(uint256(0))));
-    if (currentNonce == 0 && immutableSignerContractFound) {
+    if (currentNonce == 1 && immutableSignerContractFound) {
       return (true, true, imageHash);
     }
 

--- a/tests/ERC165.spec.ts
+++ b/tests/ERC165.spec.ts
@@ -8,6 +8,7 @@ import {
   MainModuleDynamicAuth,
   StartupWalletImpl,
   LatestWalletImplLocator,
+  ImmutableSigner,
   Factory,
   Factory__factory,
   MainModule__factory,
@@ -16,6 +17,7 @@ import {
   ERC165CheckerMock__factory,
   StartupWalletImpl__factory,
   LatestWalletImplLocator__factory,
+  ImmutableSigner__factory,
 } from '../src'
 
 ethers.utils.Logger.setLogLevel(ethers.utils.Logger.levels.ERROR)
@@ -51,6 +53,7 @@ contract('ERC165', () => {
   let moduleDynamicAuth: MainModuleDynamicAuth
   let startupWalletImpl: StartupWalletImpl
   let moduleLocator: LatestWalletImplLocator
+  let immutableSigner: ImmutableSigner
 
   let owner: ethers.Wallet
   let wallet: MainModule
@@ -70,10 +73,12 @@ contract('ERC165', () => {
     // Startup and Locator
     moduleLocator = await new LatestWalletImplLocator__factory().connect(signer).deploy(await signer.getAddress(), await signer.getAddress())
     startupWalletImpl = await new StartupWalletImpl__factory().connect(signer).deploy(moduleLocator.address)
+    // Deploy ImmutableSigner
+    immutableSigner = await new ImmutableSigner__factory().connect(signer).deploy(await signer.getAddress(), await signer.getAddress(), await signer.getAddress())
     // Deploy MainModule
     mainModule = await new MainModule__factory().connect(signer).deploy(factory.address)
     moduleUpgradable = await new MainModuleUpgradable__factory().connect(signer).deploy()
-    moduleDynamicAuth = await new MainModuleDynamicAuth__factory().connect(signer).deploy(factory.address, startupWalletImpl.address)
+    moduleDynamicAuth = await new MainModuleDynamicAuth__factory().connect(signer).deploy(factory.address, startupWalletImpl.address, immutableSigner.address)
     // Deploy ERC165 Checker
     erc165checker = await new ERC165CheckerMock__factory().connect(signer).deploy()
 

--- a/tests/ImmutableDeployment.spec.ts
+++ b/tests/ImmutableDeployment.spec.ts
@@ -93,7 +93,7 @@ describe('E2E Immutable Wallet Deployment', () => {
     // Nonce 5
     mainModuleDynamicAuth = await new MainModuleDynamicAuth__factory()
       .connect(contractDeployerEOA)
-      .deploy(factory.address, startupWallet.address)
+      .deploy(factory.address, startupWallet.address, immutableSigner.address)
 
     // Setup the latest implementation address
     await moduleLocator
@@ -283,7 +283,7 @@ describe('E2E Immutable Wallet Deployment', () => {
     )
 
     await expect(wallet.execute([transaction], nonce, signature)).to.be.revertedWith(
-      'ModuleAuth#_signatureValidation: INVALID_SIGNATURE'
+      'ModuleAuthDynamic#_signatureValidation: INVALID_SIGNATURE'
     )
   })
 
@@ -336,7 +336,7 @@ describe('E2E Immutable Wallet Deployment', () => {
     )
 
     await expect(wallet.execute([transaction], nonce, signature)).to.be.revertedWith(
-      'ModuleAuth#_signatureValidation: INVALID_SIGNATURE'
+      'ModuleAuthDynamic#_signatureValidation: INVALID_SIGNATURE'
     )
   })
 
@@ -393,7 +393,7 @@ describe('E2E Immutable Wallet Deployment', () => {
     )
 
     await expect(wallet.execute([transaction], nonce, signature)).to.be.revertedWith(
-      'ModuleAuth#_signatureValidation: INVALID_SIGNATURE'
+      'ModuleAuthDynamic#_signatureValidation: INVALID_SIGNATURE'
     )
   })
 })

--- a/tests/ImmutableStartup.spec.ts
+++ b/tests/ImmutableStartup.spec.ts
@@ -23,8 +23,12 @@ describe('Wallet Factory', function () {
     const StartupWalletImpl= await ethers.getContractFactory('StartupWalletImpl')
     const startupWalletImpl = await StartupWalletImpl.deploy(latestWalletImplLocator.address)
 
+    // Deploy ImmutableSigner contract for use in MainModuleMock deployments
+    const ImmutableSigner = await ethers.getContractFactory('ImmutableSigner')
+    const immutableSigner = await ImmutableSigner.deploy(owner.address, owner.address, owner.address)
+
     const MainModule = await ethers.getContractFactory('MainModuleMockV1')
-    const mainModuleV1 = await MainModule.deploy(factory.address, startupWalletImpl.address)
+    const mainModuleV1 = await MainModule.deploy(factory.address, startupWalletImpl.address, immutableSigner.address)
 
     await latestWalletImplLocator.changeWalletImplementation(mainModuleV1.address)
 
@@ -41,7 +45,8 @@ describe('Wallet Factory', function () {
       mainModuleV1,
       startupWalletImpl,
       salt,
-      latestWalletImplLocator
+      latestWalletImplLocator,
+      immutableSigner
 
     }
   }
@@ -132,7 +137,7 @@ describe('Wallet Factory', function () {
 
 
     it('Should be able to upgrade implementation contracts', async function () {
-      const { factory, startupWalletImpl } = await loadFixture(setupStartupFixture)
+      const { factory, startupWalletImpl, immutableSigner } = await loadFixture(setupStartupFixture)
 
       const acc = ethers.Wallet.createRandom()
       const salt = encodeImageHash(1, [{ weight: 1, address: acc.address }])
@@ -151,7 +156,7 @@ describe('Wallet Factory', function () {
 
       //console.log("Deploy MainModuleMockV2")
       const MainModuleV2 = await ethers.getContractFactory('MainModuleMockV2')
-      const mainModuleV2 = await MainModuleV2.deploy(factory.address, startupWalletImpl.address)
+      const mainModuleV2 = await MainModuleV2.deploy(factory.address, startupWalletImpl.address, immutableSigner.address)
 
       // console.log("Upgrade wallet proxy to using MainModuleMockV2")
       const networkId = (await ethers.provider.getNetwork()).chainId
@@ -201,10 +206,10 @@ describe('Wallet Factory', function () {
 
 
     it('Deploying using upgrade should work', async function () {
-      const { factory, startupWalletImpl, latestWalletImplLocator } = await loadFixture(setupStartupFixture)
+      const { factory, startupWalletImpl, latestWalletImplLocator, immutableSigner } = await loadFixture(setupStartupFixture)
 
       const MainModuleV2 = await ethers.getContractFactory('MainModuleMockV2')
-      const mainModuleV2 = await MainModuleV2.deploy(factory.address, startupWalletImpl.address)
+      const mainModuleV2 = await MainModuleV2.deploy(factory.address, startupWalletImpl.address, immutableSigner.address)
       
       await latestWalletImplLocator.changeWalletImplementation(mainModuleV2.address)
 

--- a/tests/ModuleAuthDynamic.spec.ts
+++ b/tests/ModuleAuthDynamic.spec.ts
@@ -293,7 +293,7 @@ describe('ModuleAuthDynamic Bootstrap Flow', () => {
   })
 
   describe('Bootstrap flow - Negative cases', () => {
-    it('Should reject first transaction without ImmutableSigner when wallet was not pre-deployed with correct salt', async () => {
+    it('Should accept first transaction without ImmutableSigner when image hash matches deployment salt', async () => {
       // Create a random signer that is NOT the ImmutableSigner
       const randomSigner = ethers.Wallet.createRandom().connect(hardhat.provider)
 
@@ -332,15 +332,63 @@ describe('ModuleAuthDynamic Bootstrap Flow', () => {
         false
       )
 
-      // This should still work because the wallet was deployed with the correct salt
-      // The signature validation will verify against the deployment address
-      // (This tests the existing flow, not the bootstrap flow)
+      // This should work because the signature's image hash matches the deployment salt
+      // This is the normal first-tx flow (not the bootstrap flow with ImmutableSigner)
       await wallet.execute([transaction], nonce, signature)
       expect(await wallet.nonce()).to.equal(1)
     })
 
-    it('Should reject first transaction with wrong image hash even with ImmutableSigner', async () => {
-      // Deploy wallet with specific signers
+    it('Should reject first transaction without ImmutableSigner when image hash does not match deployment salt', async () => {
+      // Create two different random signers
+      const deploymentSigner = ethers.Wallet.createRandom().connect(hardhat.provider)
+      const attackerSigner = ethers.Wallet.createRandom().connect(hardhat.provider)
+
+      // Deploy wallet with deploymentSigner
+      const walletSalt = encodeImageHash(1, [
+        { weight: 1, address: deploymentSigner.address }
+      ])
+      const walletAddress = addressOf(factory.address, startupWallet.address, walletSalt)
+      await factory.connect(walletDeployerEOA).deploy(startupWallet.address, walletSalt)
+
+      const wallet = MainModule__factory.connect(walletAddress, relayerEOA)
+
+      // Transfer funds
+      await relayerEOA.sendTransaction({ to: walletAddress, value: 1 })
+
+      const transaction = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      const networkId = (await hardhat.provider.getNetwork()).chainId
+      const nonce = 0
+      const data = encodeMetaTransactionsData(wallet.address, [transaction], networkId, nonce)
+
+      // Sign with attackerSigner (different from deployment signer, NOT ImmutableSigner)
+      // This creates a different image hash than what the wallet was deployed with
+      const signature = await walletMultiSign(
+        [
+          { weight: 1, owner: attackerSigner }
+        ],
+        1,
+        data,
+        false
+      )
+
+      // This should FAIL because:
+      // 1. Image hash doesn't match deployment salt
+      // 2. ImmutableSigner is not present to vouch via bootstrap flow
+      await expect(wallet.execute([transaction], nonce, signature)).to.be.revertedWith(
+        'ModuleCalls#execute: INVALID_SIGNATURE'
+      )
+    })
+
+    it('Should accept first transaction with different image hash when ImmutableSigner is present', async () => {
+      // Deploy wallet with specific signers (threshold 2, userEOA + immutableSigner)
       const walletSalt = encodeImageHash(2, [
         { weight: 1, address: await userEOA.getAddress() },
         { weight: 1, address: immutableSigner.address }
@@ -366,21 +414,29 @@ describe('ModuleAuthDynamic Bootstrap Flow', () => {
       const nonce = 0
       const data = encodeMetaTransactionsData(wallet.address, [transaction], networkId, nonce)
 
-      // Sign with ONLY ImmutableSigner (threshold 1, but wallet requires threshold 2)
+      // Sign with ONLY ImmutableSigner (threshold 1, but wallet was deployed with threshold 2)
       // This creates a different image hash than what the wallet was deployed with
+      // Bootstrap flow allows this because ImmutableSigner can vouch for any first transaction
       const signature = await walletMultiSign(
         [
           { weight: 1, owner: immutableSigner.address, signature: (await ethSign(immutableEOA as ethers.Wallet, data)) + '03' }
         ],
-        1,  // Wrong threshold - wallet was deployed with threshold 2
+        1,  // Different threshold than deployment - but allowed via bootstrap
         data,
         false
       )
 
-      // This should fail because the image hash doesn't match
-      await expect(wallet.execute([transaction], nonce, signature)).to.be.revertedWith(
-        'ModuleCalls#execute: INVALID_SIGNATURE'
-      )
+      const originalBalance = await randomEOA.getBalance()
+
+      // This should SUCCEED because ImmutableSigner can vouch for any first transaction
+      // regardless of whether the signature's image hash matches the deployment salt
+      await wallet.execute([transaction], nonce, signature)
+
+      // Verify funds were transferred
+      expect(await randomEOA.getBalance()).to.equal(originalBalance.add(1))
+
+      // Verify nonce incremented
+      expect(await wallet.nonce()).to.equal(1)
     })
 
     it('Should reject second transaction with wrong signers after bootstrap', async () => {

--- a/tests/ModuleAuthDynamic.spec.ts
+++ b/tests/ModuleAuthDynamic.spec.ts
@@ -1,0 +1,626 @@
+// Copyright Immutable Pty Ltd 2018 - 2023
+// SPDX-License-Identifier: Apache-2.0
+import { ethers as hardhat } from 'hardhat'
+import { ethers } from 'ethers'
+import { getContractAddress } from '@ethersproject/address'
+import {
+  Factory,
+  Factory__factory,
+  MainModule__factory,
+  ImmutableSigner,
+  ImmutableSigner__factory,
+  LatestWalletImplLocator__factory,
+  StartupWalletImpl__factory,
+  MainModuleDynamicAuth,
+  MainModuleDynamicAuth__factory,
+} from '../src'
+import {
+  encodeImageHash,
+  expect,
+  addressOf,
+  encodeMetaTransactionsData,
+  walletMultiSign,
+  ethSign,
+} from './utils'
+import { LatestWalletImplLocator, StartupWalletImpl } from 'src/gen/typechain'
+
+describe('ModuleAuthDynamic Bootstrap Flow', () => {
+  let contractDeployerEOA: ethers.Signer
+  let relayerEOA: ethers.Signer
+
+  let userEOA: ethers.Signer
+  let immutableEOA: ethers.Signer
+  let randomEOA: ethers.Signer
+  let adminEOA: ethers.Signer
+  let walletDeployerEOA: ethers.Signer
+
+  // All contracts involved in the wallet ecosystem
+  let factory: Factory
+  let mainModuleDynamicAuth: MainModuleDynamicAuth
+  let immutableSigner: ImmutableSigner
+  let moduleLocator: LatestWalletImplLocator
+  let startupWallet: StartupWalletImpl
+
+  const WALLET_FACTORY_NONCE = 1
+  const STARTUP_WALLET_NONCE = 2
+  const IMMUTABLE_SIGNER_NONCE = 3
+  const LOCATOR_NONCE = 4
+  const MAIN_MODULE_DYNAMIC_AUTH_NONCE = 5
+
+  beforeEach(async () => {
+    [
+      userEOA,
+      immutableEOA,
+      randomEOA,
+      adminEOA,
+      walletDeployerEOA,
+      relayerEOA,
+      contractDeployerEOA
+    ] = await hardhat.getSigners()
+
+    await hardhat.provider.send("hardhat_reset", [])
+
+    // Matches the production environment where the first transaction (nonce 0)
+    // is used for testing.
+    contractDeployerEOA.sendTransaction({ to: ethers.constants.AddressZero, value: 0 })
+
+    // Nonce 1
+    factory = await new Factory__factory()
+      .connect(contractDeployerEOA)
+      .deploy(await adminEOA.getAddress(), await walletDeployerEOA.getAddress())
+
+    // Calculate the locator address ahead of time
+    const moduleLocatorAddress = getContractAddress({
+      from: await contractDeployerEOA.getAddress(),
+      nonce: LOCATOR_NONCE
+    })
+
+    // Nonce 2
+    startupWallet = await new StartupWalletImpl__factory()
+      .connect(contractDeployerEOA)
+      .deploy(moduleLocatorAddress)
+
+    // Nonce 3
+    immutableSigner = await new ImmutableSigner__factory()
+      .connect(contractDeployerEOA)
+      .deploy(await adminEOA.getAddress(), await adminEOA.getAddress(), await immutableEOA.getAddress())
+
+    // NOTE: Those could possibly be deployed by a separate account instead.
+
+    // Nonce 4
+    moduleLocator = await new LatestWalletImplLocator__factory()
+      .connect(contractDeployerEOA)
+      .deploy(await adminEOA.getAddress(), await walletDeployerEOA.getAddress())
+
+    // Nonce 5
+    mainModuleDynamicAuth = await new MainModuleDynamicAuth__factory()
+      .connect(contractDeployerEOA)
+      .deploy(factory.address, startupWallet.address, immutableSigner.address)
+
+    // Setup the latest implementation address
+    await moduleLocator
+      .connect(walletDeployerEOA)
+      .changeWalletImplementation(mainModuleDynamicAuth.address)
+  })
+
+  describe('Constructor validation', () => {
+    it('Should set the IMMUTABLE_SIGNER_CONTRACT correctly', async () => {
+      expect(await mainModuleDynamicAuth.IMMUTABLE_SIGNER_CONTRACT()).to.equal(immutableSigner.address)
+    })
+  })
+
+  describe('Bootstrap flow - First transaction with ImmutableSigner', () => {
+    it('Should execute first transaction when signed by ImmutableSigner only', async () => {
+      // Deploy wallet with ImmutableSigner as the only signer (threshold 1)
+      const walletSalt = encodeImageHash(1, [
+        { weight: 1, address: immutableSigner.address }
+      ])
+      const walletAddress = addressOf(factory.address, startupWallet.address, walletSalt)
+      const walletDeploymentTx = await factory.connect(walletDeployerEOA).deploy(startupWallet.address, walletSalt)
+      await walletDeploymentTx.wait()
+
+      // Connect to the generated user address
+      const wallet = MainModule__factory.connect(walletAddress, relayerEOA)
+
+      // Transfer funds to the SCW
+      const transferTx = await relayerEOA.sendTransaction({ to: walletAddress, value: 1 })
+      await transferTx.wait()
+
+      // Verify initial nonce is 0
+      expect(await wallet.nonce()).to.equal(0)
+
+      // Return funds
+      const transaction = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      // Build meta-transaction
+      const networkId = (await hardhat.provider.getNetwork()).chainId
+      const nonce = 0
+      const data = encodeMetaTransactionsData(wallet.address, [transaction], networkId, nonce)
+
+      // Sign with ImmutableSigner only (using dynamic signature flag 03)
+      const signature = await walletMultiSign(
+        [
+          { weight: 1, owner: immutableSigner.address, signature: (await ethSign(immutableEOA as ethers.Wallet, data)) + '03' }
+        ],
+        1,
+        data,
+        false
+      )
+
+      const originalBalance = await randomEOA.getBalance()
+
+      // Execute the first transaction - this should work because ImmutableSigner is a signer
+      // and nonce will become 1 after increment (bootstrap condition)
+      const executionTx = await wallet.execute([transaction], nonce, signature)
+      await executionTx.wait()
+
+      // Verify funds were transferred
+      expect(await randomEOA.getBalance()).to.equal(originalBalance.add(1))
+
+      // Verify nonce incremented
+      expect(await wallet.nonce()).to.equal(1)
+    })
+
+    it('Should execute first transaction when ImmutableSigner is part of multi-sig', async () => {
+      // Deploy wallet with user and ImmutableSigner (threshold 2)
+      const walletSalt = encodeImageHash(2, [
+        { weight: 1, address: await userEOA.getAddress() },
+        { weight: 1, address: immutableSigner.address }
+      ])
+      const walletAddress = addressOf(factory.address, startupWallet.address, walletSalt)
+      const walletDeploymentTx = await factory.connect(walletDeployerEOA).deploy(startupWallet.address, walletSalt)
+      await walletDeploymentTx.wait()
+
+      const wallet = MainModule__factory.connect(walletAddress, relayerEOA)
+
+      // Transfer funds
+      const transferTx = await relayerEOA.sendTransaction({ to: walletAddress, value: 1 })
+      await transferTx.wait()
+
+      // Verify initial nonce is 0
+      expect(await wallet.nonce()).to.equal(0)
+
+      const transaction = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      const networkId = (await hardhat.provider.getNetwork()).chainId
+      const nonce = 0
+      const data = encodeMetaTransactionsData(wallet.address, [transaction], networkId, nonce)
+
+      // Sign with both user and ImmutableSigner
+      const signature = await walletMultiSign(
+        [
+          { weight: 1, owner: userEOA as ethers.Wallet },
+          { weight: 1, owner: immutableSigner.address, signature: (await ethSign(immutableEOA as ethers.Wallet, data)) + '03' }
+        ],
+        2,
+        data,
+        false
+      )
+
+      const originalBalance = await randomEOA.getBalance()
+
+      const executionTx = await wallet.execute([transaction], nonce, signature)
+      await executionTx.wait()
+
+      expect(await randomEOA.getBalance()).to.equal(originalBalance.add(1))
+      expect(await wallet.nonce()).to.equal(1)
+    })
+
+    it('Should store image hash after first transaction via bootstrap', async () => {
+      // Deploy wallet with ImmutableSigner as the only signer
+      const walletSalt = encodeImageHash(1, [
+        { weight: 1, address: immutableSigner.address }
+      ])
+      const walletAddress = addressOf(factory.address, startupWallet.address, walletSalt)
+      await factory.connect(walletDeployerEOA).deploy(startupWallet.address, walletSalt)
+
+      const wallet = MainModule__factory.connect(walletAddress, relayerEOA)
+
+      // Transfer funds
+      await relayerEOA.sendTransaction({ to: walletAddress, value: 1 })
+
+      const transaction = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      const networkId = (await hardhat.provider.getNetwork()).chainId
+      const nonce = 0
+      const data = encodeMetaTransactionsData(wallet.address, [transaction], networkId, nonce)
+
+      const signature = await walletMultiSign(
+        [
+          { weight: 1, owner: immutableSigner.address, signature: (await ethSign(immutableEOA as ethers.Wallet, data)) + '03' }
+        ],
+        1,
+        data,
+        false
+      )
+
+      // Execute first transaction
+      await wallet.execute([transaction], nonce, signature)
+
+      // Verify nonce is now 1
+      expect(await wallet.nonce()).to.equal(1)
+
+      // Now try to execute a second transaction - this should work because
+      // image hash was stored after the first transaction
+      await relayerEOA.sendTransaction({ to: walletAddress, value: 1 })
+
+      const transaction2 = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      const nonce2 = 1
+      const data2 = encodeMetaTransactionsData(wallet.address, [transaction2], networkId, nonce2)
+
+      const signature2 = await walletMultiSign(
+        [
+          { weight: 1, owner: immutableSigner.address, signature: (await ethSign(immutableEOA as ethers.Wallet, data2)) + '03' }
+        ],
+        1,
+        data2,
+        false
+      )
+
+      // Second transaction should succeed using stored image hash
+      await wallet.execute([transaction2], nonce2, signature2)
+      expect(await wallet.nonce()).to.equal(2)
+    })
+  })
+
+  describe('Bootstrap flow - Negative cases', () => {
+    it('Should reject first transaction without ImmutableSigner when wallet was not pre-deployed with correct salt', async () => {
+      // Create a random signer that is NOT the ImmutableSigner
+      const randomSigner = ethers.Wallet.createRandom().connect(hardhat.provider)
+
+      // Deploy wallet with random signer only (no ImmutableSigner)
+      const walletSalt = encodeImageHash(1, [
+        { weight: 1, address: randomSigner.address }
+      ])
+      const walletAddress = addressOf(factory.address, startupWallet.address, walletSalt)
+      await factory.connect(walletDeployerEOA).deploy(startupWallet.address, walletSalt)
+
+      const wallet = MainModule__factory.connect(walletAddress, relayerEOA)
+
+      // Transfer funds
+      await relayerEOA.sendTransaction({ to: walletAddress, value: 1 })
+
+      const transaction = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      const networkId = (await hardhat.provider.getNetwork()).chainId
+      const nonce = 0
+      const data = encodeMetaTransactionsData(wallet.address, [transaction], networkId, nonce)
+
+      // Sign with random signer (NOT ImmutableSigner)
+      const signature = await walletMultiSign(
+        [
+          { weight: 1, owner: randomSigner }
+        ],
+        1,
+        data,
+        false
+      )
+
+      // This should still work because the wallet was deployed with the correct salt
+      // The signature validation will verify against the deployment address
+      // (This tests the existing flow, not the bootstrap flow)
+      await wallet.execute([transaction], nonce, signature)
+      expect(await wallet.nonce()).to.equal(1)
+    })
+
+    it('Should reject first transaction with wrong image hash even with ImmutableSigner', async () => {
+      // Deploy wallet with specific signers
+      const walletSalt = encodeImageHash(2, [
+        { weight: 1, address: await userEOA.getAddress() },
+        { weight: 1, address: immutableSigner.address }
+      ])
+      const walletAddress = addressOf(factory.address, startupWallet.address, walletSalt)
+      await factory.connect(walletDeployerEOA).deploy(startupWallet.address, walletSalt)
+
+      const wallet = MainModule__factory.connect(walletAddress, relayerEOA)
+
+      // Transfer funds
+      await relayerEOA.sendTransaction({ to: walletAddress, value: 1 })
+
+      const transaction = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      const networkId = (await hardhat.provider.getNetwork()).chainId
+      const nonce = 0
+      const data = encodeMetaTransactionsData(wallet.address, [transaction], networkId, nonce)
+
+      // Sign with ONLY ImmutableSigner (threshold 1, but wallet requires threshold 2)
+      // This creates a different image hash than what the wallet was deployed with
+      const signature = await walletMultiSign(
+        [
+          { weight: 1, owner: immutableSigner.address, signature: (await ethSign(immutableEOA as ethers.Wallet, data)) + '03' }
+        ],
+        1,  // Wrong threshold - wallet was deployed with threshold 2
+        data,
+        false
+      )
+
+      // This should fail because the image hash doesn't match
+      await expect(wallet.execute([transaction], nonce, signature)).to.be.revertedWith(
+        'ModuleCalls#execute: INVALID_SIGNATURE'
+      )
+    })
+
+    it('Should reject second transaction with wrong signers after bootstrap', async () => {
+      // Deploy wallet with ImmutableSigner only
+      const walletSalt = encodeImageHash(1, [
+        { weight: 1, address: immutableSigner.address }
+      ])
+      const walletAddress = addressOf(factory.address, startupWallet.address, walletSalt)
+      await factory.connect(walletDeployerEOA).deploy(startupWallet.address, walletSalt)
+
+      const wallet = MainModule__factory.connect(walletAddress, relayerEOA)
+
+      // First transaction with ImmutableSigner
+      await relayerEOA.sendTransaction({ to: walletAddress, value: 2 })
+
+      const transaction1 = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      const networkId = (await hardhat.provider.getNetwork()).chainId
+      const data1 = encodeMetaTransactionsData(wallet.address, [transaction1], networkId, 0)
+
+      const signature1 = await walletMultiSign(
+        [
+          { weight: 1, owner: immutableSigner.address, signature: (await ethSign(immutableEOA as ethers.Wallet, data1)) + '03' }
+        ],
+        1,
+        data1,
+        false
+      )
+
+      await wallet.execute([transaction1], 0, signature1)
+      expect(await wallet.nonce()).to.equal(1)
+
+      // Now try second transaction with a DIFFERENT signer
+      const randomSigner = ethers.Wallet.createRandom().connect(hardhat.provider)
+
+      const transaction2 = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      const data2 = encodeMetaTransactionsData(wallet.address, [transaction2], networkId, 1)
+
+      const signature2 = await walletMultiSign(
+        [
+          { weight: 1, owner: randomSigner }
+        ],
+        1,
+        data2,
+        false
+      )
+
+      // This should fail because the image hash stored after first tx
+      // doesn't match the new signer configuration
+      await expect(wallet.execute([transaction2], 1, signature2)).to.be.revertedWith(
+        'ModuleCalls#execute: INVALID_SIGNATURE'
+      )
+    })
+
+    it('Should not bypass normal validation after first transaction', async () => {
+      // Deploy wallet with user and ImmutableSigner (threshold 2)
+      const walletSalt = encodeImageHash(2, [
+        { weight: 1, address: await userEOA.getAddress() },
+        { weight: 1, address: immutableSigner.address }
+      ])
+      const walletAddress = addressOf(factory.address, startupWallet.address, walletSalt)
+      await factory.connect(walletDeployerEOA).deploy(startupWallet.address, walletSalt)
+
+      const wallet = MainModule__factory.connect(walletAddress, relayerEOA)
+
+      // First transaction with both signers
+      await relayerEOA.sendTransaction({ to: walletAddress, value: 2 })
+
+      const transaction1 = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      const networkId = (await hardhat.provider.getNetwork()).chainId
+      const data1 = encodeMetaTransactionsData(wallet.address, [transaction1], networkId, 0)
+
+      const signature1 = await walletMultiSign(
+        [
+          { weight: 1, owner: userEOA as ethers.Wallet },
+          { weight: 1, owner: immutableSigner.address, signature: (await ethSign(immutableEOA as ethers.Wallet, data1)) + '03' }
+        ],
+        2,
+        data1,
+        false
+      )
+
+      await wallet.execute([transaction1], 0, signature1)
+      expect(await wallet.nonce()).to.equal(1)
+
+      // Second transaction - try with only ImmutableSigner (should fail, need both)
+      const transaction2 = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      const data2 = encodeMetaTransactionsData(wallet.address, [transaction2], networkId, 1)
+
+      // Only sign with ImmutableSigner - missing user signature
+      const signature2 = await walletMultiSign(
+        [
+          { weight: 1, owner: await userEOA.getAddress() },  // address only, no signature
+          { weight: 1, owner: immutableSigner.address, signature: (await ethSign(immutableEOA as ethers.Wallet, data2)) + '03' }
+        ],
+        2,
+        data2,
+        false
+      )
+
+      // Should fail because threshold requires both signatures but only ImmutableSigner signed
+      await expect(wallet.execute([transaction2], 1, signature2)).to.be.revertedWith(
+        'ModuleCalls#execute: INVALID_SIGNATURE'
+      )
+    })
+  })
+
+  describe('Bootstrap with EOA signer (FLAG_SIGNATURE)', () => {
+    it('Should recognize ImmutableSigner when included via FLAG_SIGNATURE', async () => {
+      // This test verifies that the bootstrap flow works when the ImmutableSigner
+      // is detected through a recovered address from signature (FLAG_SIGNATURE = 0)
+      // rather than through FLAG_DYNAMIC_SIGNATURE (03)
+      
+      // For this to work, we need to use the ImmutableSigner's underlying EOA address
+      // directly as the signer in the image hash
+
+      // Deploy wallet where immutableEOA (the underlying EOA) is a signer
+      // Note: This is a different configuration than using ImmutableSigner contract
+      const walletSalt = encodeImageHash(1, [
+        { weight: 1, address: await immutableEOA.getAddress() }
+      ])
+      const walletAddress = addressOf(factory.address, startupWallet.address, walletSalt)
+      await factory.connect(walletDeployerEOA).deploy(startupWallet.address, walletSalt)
+
+      const wallet = MainModule__factory.connect(walletAddress, relayerEOA)
+
+      await relayerEOA.sendTransaction({ to: walletAddress, value: 1 })
+
+      const transaction = {
+        delegateCall: false,
+        revertOnError: true,
+        gasLimit: 1000000,
+        target: await randomEOA.getAddress(),
+        value: 1,
+        data: []
+      }
+
+      const networkId = (await hardhat.provider.getNetwork()).chainId
+      const nonce = 0
+      const data = encodeMetaTransactionsData(wallet.address, [transaction], networkId, nonce)
+
+      // Sign directly with the EOA (not through ImmutableSigner contract)
+      const signature = await walletMultiSign(
+        [
+          { weight: 1, owner: immutableEOA as ethers.Wallet }
+        ],
+        1,
+        data,
+        false
+      )
+
+      const originalBalance = await randomEOA.getBalance()
+
+      // This should work because:
+      // 1. The wallet was deployed with immutableEOA as signer
+      // 2. The signature is valid
+      // Note: This does NOT trigger the bootstrap bypass since immutableEOA != IMMUTABLE_SIGNER_CONTRACT
+      // It uses the normal first-tx flow (validates against deployment address)
+      await wallet.execute([transaction], nonce, signature)
+
+      expect(await randomEOA.getBalance()).to.equal(originalBalance.add(1))
+      expect(await wallet.nonce()).to.equal(1)
+    })
+  })
+
+  describe('Multiple transactions after bootstrap', () => {
+    it('Should allow multiple consecutive transactions after bootstrap', async () => {
+      // Deploy wallet with ImmutableSigner only
+      const walletSalt = encodeImageHash(1, [
+        { weight: 1, address: immutableSigner.address }
+      ])
+      const walletAddress = addressOf(factory.address, startupWallet.address, walletSalt)
+      await factory.connect(walletDeployerEOA).deploy(startupWallet.address, walletSalt)
+
+      const wallet = MainModule__factory.connect(walletAddress, relayerEOA)
+
+      // Fund the wallet for multiple transactions
+      await relayerEOA.sendTransaction({ to: walletAddress, value: 5 })
+
+      const networkId = (await hardhat.provider.getNetwork()).chainId
+
+      // Execute 5 transactions
+      for (let nonce = 0; nonce < 5; nonce++) {
+        const transaction = {
+          delegateCall: false,
+          revertOnError: true,
+          gasLimit: 1000000,
+          target: await randomEOA.getAddress(),
+          value: 1,
+          data: []
+        }
+
+        const data = encodeMetaTransactionsData(wallet.address, [transaction], networkId, nonce)
+
+        const signature = await walletMultiSign(
+          [
+            { weight: 1, owner: immutableSigner.address, signature: (await ethSign(immutableEOA as ethers.Wallet, data)) + '03' }
+          ],
+          1,
+          data,
+          false
+        )
+
+        const originalBalance = await randomEOA.getBalance()
+        await wallet.execute([transaction], nonce, signature)
+        expect(await randomEOA.getBalance()).to.equal(originalBalance.add(1))
+        expect(await wallet.nonce()).to.equal(nonce + 1)
+      }
+    })
+  })
+})
+

--- a/tests/ModuleAuthDynamic.spec.ts
+++ b/tests/ModuleAuthDynamic.spec.ts
@@ -568,9 +568,10 @@ describe('ModuleAuthDynamic Bootstrap Flow', () => {
         false
       )
 
-      // Should fail because threshold requires both signatures but only ImmutableSigner signed
+      // Should fail because FLAG_ADDRESS is not supported in ModuleAuthDynamic
+      // (removed to prevent attackers from including addresses without signatures)
       await expect(wallet.execute([transaction2], 1, signature2)).to.be.revertedWith(
-        'ModuleCalls#execute: INVALID_SIGNATURE'
+        'ModuleAuthDynamic#_signatureValidation INVALID_FLAG'
       )
     })
   })

--- a/tests/RequireUtils.spec.ts
+++ b/tests/RequireUtils.spec.ts
@@ -17,8 +17,9 @@ import {
 
 ethers.utils.Logger.setLogLevel(ethers.utils.Logger.levels.ERROR)
 
-function now(): number {
-  return Math.floor(Date.now() / 1000)
+async function getBlockTimestamp(): Promise<number> {
+  const block = await web3.eth.getBlock('latest')
+  return Number(block.timestamp)
 }
 
 const optimalGasLimit = ethers.constants.Two.pow(21)
@@ -328,14 +329,17 @@ contract('Require utils', (accounts: string[]) => {
   })
   describe('Expirable transactions', () => {
     it('Should pass if non expired', async () => {
-      await requireUtils.requireNonExpired(now() + 1480)
+      const blockTimestamp = await getBlockTimestamp()
+      await requireUtils.requireNonExpired(blockTimestamp + 1480)
     })
     it('Should fail if expired', async () => {
-      const tx = requireUtils.requireNonExpired(now() - 1)
+      const blockTimestamp = await getBlockTimestamp()
+      const tx = requireUtils.requireNonExpired(blockTimestamp - 1)
       await expect(tx).to.be.rejectedWith(RevertError('RequireUtils#requireNonExpired: EXPIRED'))
     })
     it('Should pass bundle if non expired', async () => {
       const callReceiver = await new CallReceiverMock__factory().connect(signer).deploy()
+      const blockTimestamp = await getBlockTimestamp()
 
       const valA = 5423
       const valB = web3.utils.randomHex(120)
@@ -347,7 +351,7 @@ contract('Require utils', (accounts: string[]) => {
           gasLimit: optimalGasLimit,
           target: requireUtils.address,
           value: ethers.constants.Zero,
-          data: requireUtils.interface.encodeFunctionData('requireNonExpired', [now() + 1480])
+          data: requireUtils.interface.encodeFunctionData('requireNonExpired', [blockTimestamp + 1480])
         },
         {
           delegateCall: false,
@@ -365,6 +369,7 @@ contract('Require utils', (accounts: string[]) => {
     })
     it('Should fail bundle if expired', async () => {
       const callReceiver = await new CallReceiverMock__factory().connect(signer).deploy()
+      const blockTimestamp = await getBlockTimestamp()
 
       const valA = 5423
       const valB = web3.utils.randomHex(120)
@@ -376,7 +381,7 @@ contract('Require utils', (accounts: string[]) => {
           gasLimit: optimalGasLimit,
           target: requireUtils.address,
           value: ethers.constants.Zero,
-          data: requireUtils.interface.encodeFunctionData('requireNonExpired', [now() - 1])
+          data: requireUtils.interface.encodeFunctionData('requireNonExpired', [blockTimestamp - 1])
         },
         {
           delegateCall: false,


### PR DESCRIPTION
**Summary:**
This PR implements support for the bootstrap flow in the v1 wallet system. This is done by checking if the initial txn is signed by the Immutable signer without requiring a pre-stored image hash.

**Motivation:**

**Pre-change:**
When a new wallet is created, the image hash (representing the wallet's signer configuration) needs to be stored before transactions can be validated. In the absence of the imageHash, the first transaction is validated by recalculating the CREATE2 address of the wallet using the imageHash as the salt. The imageHash is retrieved from the signed message and the message payload. If the calculated address (CFA) matches the deployed wallet address then the imageHash is stored and used to validate subsequent transactions.

**The problem**
Currently in the Immutable ZKEVM chain, the primary wallet owner / signer identity instrument is stored by a 3rd party and we access the signer via their TEE. In a multi-chain world, we would potentially be integrating with different infrastructure providers across chain and therefore have different signers. 
The primary wallet owner / signer influences the CFA i.e the user's Passport wallet address and since we need to preserve the same CFA, the current model of validating the first transaction by verifying if the recalculated wallet CFA matches the deployed wallet address doesn't work.

**Post-change**
To work around the above problem, this PR introduces the following changes:
- A new wallet's first transaction is submitted with a signature from the Immutable Signer contract
- During signature validation, the contract checks:
  - If the current nonce is 1 (meaning this is the first transaction, since nonce was 0 before increment)
  - If the Immutable Signer contract address is among the signers in the signature
  - If both conditions are met, the signature is automatically approved and the computed image hash is stored
- Subsequent transactions follow the standard validation path, checking against the stored image hash

Overall Flow:
<img width="6244" height="4206" alt="Passport - Initial Txn-2025-12-04-043344" src="https://github.com/user-attachments/assets/ba387fe3-2af9-41da-b864-bb72f777530d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces immutable signer–based bootstrap to validate the first wallet transaction without user signature, updating constructors, deployments, and compiler settings.
> 
> - **Contracts**:
>   - **`ModuleAuthDynamic`**: Adds `IMMUTABLE_SIGNER_CONTRACT` and overrides signature validation to auto-approve first tx (nonce=0) when immutable signer is present; integrates nonce/image checks via `ModuleStorage`/`NonceKey`.
>   - **`MainModuleDynamicAuth` + mocks (`MainModuleMockV1/2/3`)**: Constructors now accept and pass `_immutableSignerContract`.
>   - **`ModuleAuth`**: Exposes `FLAG_*` as `internal`; marks validation functions `virtual` to enable overrides.
> - **Deployment**:
>   - **`scripts/deploy.ts` & `scripts/step4.ts`**: Deploy `ImmutableSigner` before `MainModuleDynamicAuth` and supply its address during deployment; output includes immutable signer details.
> - **Build/Config**:
>   - **`hardhat.config.ts`**: Enables `viaIR` in Solidity compiler settings.
>   - **`.gitignore`**: Ignores `lib/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7716f6532530d5aba56b1f75c2dcc96b9c9c95ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->