### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Global owner
+@immutable/rollups
+
+# Github actions
+.github @immutable/rollups  @immutable/security

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global owner
-@immutable/rollups
+* @immutable/rollups
 
 # Github actions
 .github @immutable/rollups  @immutable/security

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 * @immutable/rollups
 
 # Github actions
-.github @immutable/rollups  @immutable/security
+/.github/ @immutable/rollups  @immutable/security


### PR DESCRIPTION
Add CODEOWNERS file. The file makes the rollups team responsible for the repo in general and the rollups and the security teams responsible for the github actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repo metadata-only change that affects review routing but not runtime code or production behavior.
> 
> **Overview**
> Adds a `CODEOWNERS` file to enforce review ownership across the repo.
> 
> Sets `@immutable/rollups` as the global owner and requires both `@immutable/rollups` and `@immutable/security` to review changes under `.github` (GitHub Actions/workflows).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9632adcec519280ba3f4f494a1e691d116d8e60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->